### PR TITLE
Remove taskYIELD() Calls

### DIFF
--- a/components/lvgl_ili9341/Kconfig
+++ b/components/lvgl_ili9341/Kconfig
@@ -66,7 +66,7 @@ menu "LittlevGL (LVGL)"
         
     config LVGL_BACKLIGHT_ACTIVE_LVL
         bool
-        prompt "Is backlight turn on with a HIGH (1) logic level?" if LVGL_ENABLE_BACKLIGHT_CONTROL
+        prompt "Is backlight turn on with a HIGH (1) logic level?" if LVGL_ENABLE_BACKLIGHT_CONTROL && LVGL_PREDEFINED_DISPLAY_NONE
         default y if LVGL_PREDEFINED_DISPLAY_M5STACK
         default n if LVGL_PREDEFINED_DISPLAY_WROVER4
         default n

--- a/components/lvgl_ili9341/ili9341.c
+++ b/components/lvgl_ili9341/ili9341.c
@@ -166,21 +166,21 @@ void ili9341_enable_backlight(bool backlight)
 
 static void ili9341_send_cmd(uint8_t cmd)
 {
-	  while(disp_spi_is_busy()) {};
+	  while(disp_spi_is_busy()) {}
 	  gpio_set_level(ILI9341_DC, 0);	 /*Command mode*/
 	  disp_spi_send_data(&cmd, 1);
 }
 
 static void ili9341_send_data(void * data, uint16_t length)
 {
-	  while(disp_spi_is_busy()) {};
+	  while(disp_spi_is_busy()) {}
 	  gpio_set_level(ILI9341_DC, 1);	 /*Data mode*/
 	  disp_spi_send_data(data, length);
 }
 
 static void ili9341_send_color(void * data, uint16_t length)
 {
-		while(disp_spi_is_busy()) {};
+		while(disp_spi_is_busy()) {}
     gpio_set_level(ILI9341_DC, 1);   /*Data mode*/
     disp_spi_send_colors(data, length);
 }

--- a/components/lvgl_ili9341/ili9341.c
+++ b/components/lvgl_ili9341/ili9341.c
@@ -166,27 +166,21 @@ void ili9341_enable_backlight(bool backlight)
 
 static void ili9341_send_cmd(uint8_t cmd)
 {
-	  while(disp_spi_is_busy()) {
-			taskYIELD();
-		};
+	  while(disp_spi_is_busy()) {};
 	  gpio_set_level(ILI9341_DC, 0);	 /*Command mode*/
 	  disp_spi_send_data(&cmd, 1);
 }
 
 static void ili9341_send_data(void * data, uint16_t length)
 {
-	  while(disp_spi_is_busy()) {
-			taskYIELD();
-		};
+	  while(disp_spi_is_busy()) {};
 	  gpio_set_level(ILI9341_DC, 1);	 /*Data mode*/
 	  disp_spi_send_data(data, length);
 }
 
 static void ili9341_send_color(void * data, uint16_t length)
 {
-		while(disp_spi_is_busy()) {
-			taskYIELD();
-		};
+		while(disp_spi_is_busy()) {};
     gpio_set_level(ILI9341_DC, 1);   /*Data mode*/
     disp_spi_send_colors(data, length);
 }


### PR DESCRIPTION
At the tail-end of #25, I had to make a change to support GCC 8.2 as it failed with a warning on while loops without a body.  I should have just made it empty braces on the busy waits, but at the time our discussion seemed to be leaning in the direction of adding a `taskYIELD()` in those loops. I mentioned that in [my last comment ](https://github.com/littlevgl/lv_port_esp32_ili9341/pull/25#issuecomment-548175391
) but maybe it was overlooked, and in our discussion of #30 I neglected to mention we already had some of these in the code base. Since we concluded there we don't need them, we should take them out now.

Also, I fix a minor KConfig issue: when you pick a pre-defined display (M5 or WRover Kit 4.1) you shouldn't see the backlight prompts since we already fill the correct values for those. 